### PR TITLE
:rotating_light: ruffのEXE002に対する警告を無視するように設定

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ ignore = [
   # The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`.
   "COM812",
   "ISC001",
+  "EXE002", # `no-exec` (EXE002) and `no-shell` (EXE003) are incompatible.
 ]
 select = ["ALL"]
 


### PR DESCRIPTION
EXE002はpythonスクリプトの場合、先頭にshebangをつけることとなっているが、pythonで呼び出すので不要。